### PR TITLE
Fix empty cssRules

### DIFF
--- a/src/CheckCSS.ts
+++ b/src/CheckCSS.ts
@@ -146,12 +146,19 @@ export class CheckCSS {
     try {
       rules = isGroupingRule(sheet) ? sheet?.cssRules : sheet.sheet?.cssRules;
     } catch (e) {
-      console.log(
-        '%ccheckcss:',
-        'color: darkorange',
-        'Inaccessible stylesheet may contain classes reported as undefined.  Use `onClassnameDetected` to ignore erroneously reported classes.',
-        sheet
-      );
+      if (!(e instanceof Error)) throw e;
+
+      if (e.name === 'SecurityError') {
+        console.log(
+          '%ccheckcss:',
+          'color: darkorange',
+          'Inaccessible stylesheet may contain classes reported as undefined.  Use `onClassnameDetected` to ignore erroneously reported classes.',
+          sheet
+        );
+      } else {
+        e.message += '\n\n(Please report this error to https://github.com/broofa/checkcss/issues)';
+        throw e;
+      }
     }
 
     if (!rules) return;

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,7 +5,7 @@ const CLASS_IDENT_REGEX =
   /\.-?(?:[_a-z]|[^\0-\x7f]|\\[0-9a-f]{1,6}\s?|\\[^\s0-9a-f])(?:[_a-z0-9-]|[^\0-\x7f]|\\[0-9a-f]{1,6}\s?|\\[^\s0-9a-f])*/gi;
 
 export function isGroupingRule(rule: any): rule is CSSGroupingRule {
-  return rule && 'cssRules' in rule;
+  return rule && 'cssRules' in rule && rule.cssRules.length > 0;
 }
 
 export function isCSSStyleRule(rule: any): rule is CSSStyleRule {

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,7 +5,7 @@ const CLASS_IDENT_REGEX =
   /\.-?(?:[_a-z]|[^\0-\x7f]|\\[0-9a-f]{1,6}\s?|\\[^\s0-9a-f])(?:[_a-z0-9-]|[^\0-\x7f]|\\[0-9a-f]{1,6}\s?|\\[^\s0-9a-f])*/gi;
 
 export function isGroupingRule(rule: any): rule is CSSGroupingRule {
-  return rule && 'cssRules' in rule && rule.cssRules.length > 0;
+  return (rule?.cssRules?.length ?? 0) > 0;
 }
 
 export function isCSSStyleRule(rule: any): rule is CSSStyleRule {


### PR DESCRIPTION
In our case, `#processStylesheet` doesn't detect any classes.

Going deeper, it comes from the method `isGroupingRule` because the object "rule" has "cssRules" but is empty. 
So, rule never pass through `isCSSStyleRule` method just after.